### PR TITLE
Fixes build path

### DIFF
--- a/kocha/build.go
+++ b/kocha/build.go
@@ -63,9 +63,11 @@ func (c *buildCommand) Run() {
 	if err != nil {
 		panic(err)
 	}
+	dstBasePath := filepath.Join(filepath.SplitList(build.Default.GOPATH)[0], "src")
+	appDir := filepath.ToSlash(dir)[len(dstBasePath)+1:]
 	appName := filepath.Base(dir)
-	configPkg := c.Package(path.Join(appName, "config", env))
-	controllersPkg := c.Package(path.Join(appName, "app", "controllers"))
+	configPkg := c.Package(path.Join(appDir, "config", env))
+	controllersPkg := c.Package(path.Join(appDir, "app", "controllers"))
 	tmpDir, err := filepath.Abs("tmp")
 	if err != nil {
 		panic(err)

--- a/kocha/skeleton/new/config/app.go
+++ b/kocha/skeleton/new/config/app.go
@@ -44,8 +44,8 @@ var (
 		MaxClientBodySize: 1024 * 1024 * 10, // 10MB
 	}
 
-	_, configFileName, _, _ = runtime.Caller(0)
-	rootPath                = filepath.Dir(filepath.Join(configFileName, ".."))
+	_, configFileName, _, _ = runtime.Caller(1)
+	rootPath                = filepath.Dir(filepath.Join(configFileName, "..", ".."))
 )
 
 func init() {


### PR DESCRIPTION
I'm thinking below should be work.

```
$ kocha new github.com/mattn/foobarbaz
$ cd /path/to/my/gopath/src/github.com/mattn/foobarbaz
$ kocha b dev
$ kocha run
```

But currently, it doesn't work. It seems `kocha b dev` are looking `/path/to/my/gopath/src/foobarbaz`.
