### PR TITLE
Fix controller.Params is always empty

### DIFF
--- a/server.go
+++ b/server.go
@@ -18,6 +18,7 @@ const fdKey = "KOCHA_FD"
 
 func handler(writer http.ResponseWriter, req *http.Request) {
 	controller, method, args := appConfig.router.dispatch(req)
+	req.ParseForm()
 	if controller == nil {
 		c := NewErrorController(http.StatusNotFound)
 		cValue := reflect.ValueOf(c)


### PR DESCRIPTION
controller.Params is always empty.
This cause is that http.Request.ParseForm() is not called.

So, I added call req.ParseForm() to handler's top at this PR.

thank you!
